### PR TITLE
Create WP_Slack_Plugin after all plugins have loaded

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -28,6 +28,8 @@ require_once __DIR__ . '/includes/autoloader.php';
 // Register the autoloader.
 WP_Slack_Autoloader::register( 'WP_Slack', trailingslashit( plugin_dir_path( __FILE__ ) ) . '/includes/' );
 
-// Runs this plugin.
-$GLOBALS['wp_slack'] = new WP_Slack_Plugin();
-$GLOBALS['wp_slack']->run( __FILE__ );
+// Runs this plugin after all plugins are loaded.
+add_action( 'plugins_loaded', function() {
+  $GLOBALS['wp_slack'] = new WP_Slack_Plugin();
+  $GLOBALS['wp_slack']->run( __FILE__ );
+});


### PR DESCRIPTION
The WP_Slack_Plugin was created when the plugin loaded.

Additional plugins that add themselves to the `slack_get_events` filter may not have been loaded yet at that point.

So the plugin creates a new `WP_Slack_Event_Manager` object that runs `get_events()` before those "late" plugins have had a chance to hook into the event.

Fixes #38 
