### PR TITLE
Add ability to use Slack attachments

### DIFF
--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -176,19 +176,29 @@ class WP_Slack_Event_Manager {
 
 		$callback = function() use( $event, $setting, $notifier ) {
 			$message = '';
-			if ( is_string( $event['message'] ) ) {
+			if ( is_string( $event['message'] ) || is_array( $event['message'] ) ) {
 				$message = $event['message'];
 			} else if ( is_callable( $event['message'] ) ) {
 				$message = call_user_func_array( $event['message'], func_get_args() );
 			}
 
 			if ( ! empty( $message ) ) {
-				$setting = wp_parse_args(
-					array(
-						'text' => $message,
-					),
-					$setting
-				);
+				if ( is_string( $message ) ) {
+					$setting = wp_parse_args(
+						array(
+							'text' => $message,
+						),
+						$setting
+					);
+				} else if ( is_array( $message ) ) {
+					$setting = wp_parse_args(
+						array(
+							'attachments' => $message,
+						),
+						$setting
+					);
+					unset( $setting['text'] );
+				}
 
 				$notifier->notify( new WP_Slack_Event_Payload( $setting ) );
 			}

--- a/includes/event-payload.php
+++ b/includes/event-payload.php
@@ -21,6 +21,7 @@ class WP_Slack_Event_Payload {
 			'username'     => $this->setting['username'],
 			'text'         => $this->setting['text'],
 			'icon_emoji'   => $this->setting['icon_emoji'],
+			'attachments'  => $this->setting['attachments'],
 		) );
 	}
 }


### PR DESCRIPTION
First quick approach to enable Slack attachments as payload:

If the message is a string, it is posted as 'text'. If the message is an array, it is posted as 'attachments'.

It should be an array of arrays: each main element is an attachment, and each attachment has attributes within it.

See https://api.slack.com/docs/attachments
