### PR TITLE
Bump tested up to field in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Send notifications to Slack channels when certain events in WordPress occur.
 **Contributors:** [akeda](http://profiles.wordpress.org/akeda), [reedyn](http://profiles.wordpress.org/reedyn)  
 **Tags:** [slack](http://wordpress.org/plugins/tags/slack), [api](http://wordpress.org/plugins/tags/api), [chat](http://wordpress.org/plugins/tags/chat), [notification](http://wordpress.org/plugins/tags/notification)  
 **Requires at least:** 3.6  
-**Tested up to:** 3.9  
+**Tested up to:** 4.7  
 **Stable tag:** trunk (master)  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Donate link:** http://goo.gl/DELyuR  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      akeda, reedyn
 Donate link:       http://goo.gl/DELyuR
 Tags:              slack, api, chat, notification
 Requires at least: 3.6
-Tested up to:      3.9
+Tested up to:      4.7
 Stable tag:        0.5.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Didn't notice any issues with the latest WordPress version so I guess it's fine to bump the version in the tested up to field.

Deploying this change would also remove the update warning on https://wordpress.org/plugins/slack/.