### PR TITLE
allow user to add which post type to send the notification per settings

### DIFF
--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -239,6 +239,13 @@ class WP_Slack_Event_Manager {
 			if ( is_string( $event['message'] ) ) {
 				$message = $event['message'];
 			} elseif ( is_callable( $event['message'] ) ) {
+				if ( isset( $setting['post_types'] ) ) {
+					$post_types = explode( ',', trim( $setting['post_types'] ) );
+					$args       = func_get_args();
+					if ( isset( $args[2] ) && is_a( $args[2], '\WP_Post', true ) && ! empty( $post_types ) && ! in_array( get_post_type( $args[2]->ID ), $post_types, true ) ) {
+						return;
+					}
+				}
 				$callback_args = func_get_args();
 				$message       = call_user_func_array( $event['message'], $callback_args );
 			}

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -106,6 +106,7 @@ class WP_Slack_Post_Meta_Box {
 			'channel'     => 'sanitize_text_field',
 			'username'    => 'sanitize_text_field',
 			'icon_emoji'  => 'sanitize_text_field',
+			'post_types'  => 'sanitize_text_field',
 			'active'      => function( $val ) {
 				if ( $val ) {
 					return true;

--- a/views/post-meta-box.php
+++ b/views/post-meta-box.php
@@ -95,6 +95,19 @@
 			</td>
 		</tr>
 
+		<tr valign="top">
+			<th scope="row">
+				<label for="slack_setting[post_types]"><?php esc_html_e( 'Post Types', 'slack' ); ?></label>
+			</th>
+			<td>
+				<input type="text" class="regular-text" name="slack_setting[post_types]" id="slack_setting[post_types]"
+					   value="<?php echo ! empty( $setting['post_types'] ) ? esc_attr( $setting['post_types'] ) : ''; ?>">
+				<p class="description">
+					<?php esc_html_e( 'Which post_types should trigger this notification? It is comma separated, ex: post,page. This is optional.', 'slack' ); ?>
+				</p>
+			</td>
+		</tr>
+
 		<?php if ( 'publish' === $post->post_status ) : ?>
 		<tr valign="top">
 			<th scope="row"></th>


### PR DESCRIPTION
This PR allow user to choose which post type per settings they want to send the notification.
This will allow the case when the user want to send notification to a different slack channel based on post_types.

Please check my PR and let me know what you think.