### PR TITLE
Avoid `add_filter post_class` during `wp_doing_ajax()`, fixes #58

### DIFF
--- a/includes/post-type.php
+++ b/includes/post-type.php
@@ -460,6 +460,10 @@ class WP_Slack_Post_Type {
 			return $classes;
 		}
 
+		if ( wp_doing_ajax() ) {
+			return $classes;
+		}
+
 		$screen = get_current_screen();
 		if ( sprintf( 'edit-%s', $this->name ) !== $screen->id ) {
 			return $classes;


### PR DESCRIPTION
I'm not sure if `$screen` and adding `slack_integration` post classes are relevant during AJAX calls in any scenario, so I'm blocking them out completely right now.

In theory, the `{in}active` post classes might be useful, but this requires some more function re-architecting. Not sure if worth it.