### PR TITLE
[i18n] Bump minimum WP version to 4.6 to allow localization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Send notifications to Slack channels when certain events in WordPress occur.
 
 **Contributors:** [akeda](https://profiles.wordpress.org/akeda), [reedyn](https://profiles.wordpress.org/reedyn)<br>
 **Tags:** [slack](https://wordpress.org/plugins/tags/slack), [api](https://wordpress.org/plugins/tags/api), [chat](https://wordpress.org/plugins/tags/chat), [notification](https://wordpress.org/plugins/tags/notification)<br>
-**Requires at least:** 4.3<br>
+**Requires at least:** 4.6<br>
 **Tested up to:** 4.7.3<br>
 **Stable tag:** 0.6.0<br>
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)<br>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      akeda, reedyn
 Donate link:       http://goo.gl/DELyuR
 Tags:              slack, api, chat, notification
-Requires at least: 4.3
+Requires at least: 4.6
 Tested up to:      4.7.3
 Stable tag:        0.6.0
 License:           GPLv2 or later

--- a/slack.php
+++ b/slack.php
@@ -15,7 +15,7 @@
  * Text Domain: slack
  * Domain Path: /languages
  * License: GPL v2 or later
- * Requires at least: 4.3
+ * Requires at least: 4.6
  * Tested up to: 4.7.3
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Please check out https://wp-info.org/tools/checkplugini18n.php?slug=slack

Fix issue #72